### PR TITLE
Add preview cutout

### DIFF
--- a/scripts/userscript.user.js
+++ b/scripts/userscript.user.js
@@ -35,5 +35,14 @@ if (window.top !== window.self) {
 			img.src = src;
 		}
 		addImage("https://raw.githubusercontent.com/TheGeka/pixel/main/output.png", 0, 0);
+		const waitForPreview = setInterval(() => {
+			const preview = camera.querySelector("mona-lisa-pixel-preview");
+			if (preview) {
+			  clearInterval(waitForPreview);
+			  const style = document.createElement('style')
+			  style.innerHTML = '.pixel { clip-path: polygon(-20% -20%, -20% 120%, 37% 120%, 37% 37%, 62% 37%, 62% 62%, 37% 62%, 37% 120%, 120% 120%, 120% -20%); }'
+			  preview.shadowRoot.appendChild(style);
+			}
+		}, 100);
 	}, false);
 }


### PR DESCRIPTION
Add a cutout in the center of the preview pixel to view the overlay or the current pixel while selecting the color.
This is taken from the osu! overlay script, might be useful here since there a lot of colors now.

![Example image](https://user-images.githubusercontent.com/28684831/161449700-5baee1b3-08fe-4a5f-9d31-71905d0d2170.png)